### PR TITLE
Fix Windows compilation of .mirah files

### DIFF
--- a/lib/mirah.rb
+++ b/lib/mirah.rb
@@ -156,7 +156,7 @@ class DubyImpl
         filename = "#{@state.destination}#{filename}"
         FileUtils.mkdir_p(File.dirname(filename))
         bytes = builder.generate
-        File.open(filename, 'w') {|f| f.write(bytes)}
+        File.open(filename, 'wb') {|f| f.write(bytes)}
       end
       @filename = nil
     end


### PR DESCRIPTION
Hi, Charlie and crew.

Mirah currently opens the generated <code>.class</code> file in <code>w</code> mode, which is causing Windows to insert a carriage return before each line feed.  I've changed the file mode to <code>wb</code>, and Mirah is now generating good class files on my machine.

The attached pull request contains the fix.

--Ian
