### PR TITLE
Use to_source to generate exception names

### DIFF
--- a/lib/mirah/jvm/source_generator/builder.rb
+++ b/lib/mirah/jvm/source_generator/builder.rb
@@ -363,7 +363,7 @@ module Duby
           print ' throws '
           @exceptions.each_with_index do |exception, i|
             print ', ' unless i == 0
-            print exception.name
+            print exception.to_source
           end
         end
         if @abstract


### PR DESCRIPTION
The java source code is wrong when an exteption is into a class. The source generator creates this for instance:

throws hudson.model.Descriptor$FormException

rather than:

throws hudson.mode.Descriptor.FormException

This commit fix the problem
