### PR TITLE
Fix build issues introduced in a recent refactor (+ fix test_empty_array)

### DIFF
--- a/lib/mirah/ast/intrinsics.rb
+++ b/lib/mirah/ast/intrinsics.rb
@@ -320,7 +320,7 @@ module Mirah::AST
           raise e
         end
       ensure
-        puts ast.inspect if transformer.state.verbose
+        puts ast.inspect if transformer.verbose?
       end
       # FIXME: This is JVM specific, and should move out of platform-independent code
       compiler = Mirah::JVM::Compiler::JVMBytecode.new

--- a/lib/mirah/parser.rb
+++ b/lib/mirah/parser.rb
@@ -15,6 +15,7 @@
 
 require 'mirah/util/process_errors'
 require 'mirah/transform'
+require 'mirah/util/compilation_state'
 require 'java'
 
 module Mirah
@@ -22,6 +23,7 @@ module Mirah
     include Mirah::Util::ProcessErrors
     
     def initialize(logging)
+      @state = Mirah::Util::CompilationState.new
       @transformer = Mirah::Transform::Transformer.new(@state)
       Java::MirahImpl::Builtin.initialize_builtins(@transformer)
       @logging = logging
@@ -53,7 +55,7 @@ module Mirah
     end
     
     def parse_file(filename)
-      puts "  #{duby_file}" if logging
+      puts "  #{filename}" if logging
       parse_and_transform(filename, File.read(filename))
     end
     
@@ -73,7 +75,7 @@ module Mirah
         if File.directory?(filename)
           Dir[File.join(filename, '*')].each do |child|
             if File.directory?(child)
-              files << child
+              files_or_scripts << child
             elsif child =~ /\.(duby|mirah)$/
               expanded << child
             end

--- a/test/test_ast.rb
+++ b/test/test_ast.rb
@@ -357,10 +357,13 @@ class TestAst < Test::Unit::TestCase
   def test_empty_array
     new_ast = AST.parse("int[5]").body[0]
 
+    new_ast.infer(Typer::Simple.new(new_ast), true)
+
     assert_not_nil(new_ast)
     assert(AST::EmptyArray === new_ast)
     assert_equal(5, new_ast.size.literal)
-    assert_equal(AST.type(:int), new_ast.inferred_type)
+    array_of_int = AST.type(nil, AST.type(nil, :int), true)
+    assert_equal(array_of_int, new_ast.inferred_type!)
   end
 
   def test_block_comment


### PR DESCRIPTION
This fixes a few build issues introduced in the recent refactor and gets test_empty_array passing (which was broken in 0.0.7 too, apparently).

Not sure if my fix for test_empty_array is entirely legitimate?

First patch, and it's quite small, but would appreciate any feedback.
