### PR TITLE
Fixed "Don't know how to build task 'bootstrap'" error

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -138,7 +138,7 @@ task :zip => 'jar:complete' do
 end
 
 desc "Build the gem file"
-task :gem => :bootstrap do
+task :gem => "jar:bootstrap" do
   sh 'gem build mirah.gemspec'
 end
 


### PR DESCRIPTION
The current Rakefile defines "jar:bootstrap" but later references plain "bootstrap" as a dependency for "gem".

This commit fixes the dependency and points to "jar:bootstrap", thus allowing "rake gem" to work.
