### PR TITLE
Trying to get a block passed as an interface implementation that returns a value working

### DIFF
--- a/test/test_jvm_compiler.rb
+++ b/test/test_jvm_compiler.rb
@@ -2094,6 +2094,22 @@ class TestJVMCompiler < Test::Unit::TestCase
       cls.main(nil)
     end
   end
+  
+  def test_block_with_no_arguments_and_return_value
+    cls, = compile(<<-EOF)
+      import java.util.concurrent.Callable
+      def foo c:Callable
+         puts c.call
+      end
+      foo do
+        "an object"
+      end
+    EOF
+    assert_output("an object\n") do
+      cls.main(nil)
+    end
+
+  end
 
   def test_each
     cls, = compile(<<-EOF)


### PR DESCRIPTION
Right now it gives an inference error. I'm guessing that the block is added as the body after the method's types are inferred, but I don't know enough about that process to fix it.

So, I thought I'd add a failing test for it.
