### PR TITLE
fix closure scope issue, javac issue

### DIFF
--- a/lib/mirah/ast/structure.rb
+++ b/lib/mirah/ast/structure.rb
@@ -208,7 +208,7 @@ module Mirah::AST
                             args.dup) do |mdef|
           mdef.static_scope = static_scope
           mdef.binding_type = binding
-          body.dup
+          mdef.body = body.dup
         end
         typer.infer(mdef.body, method.return_type != typer.no_type)
       end

--- a/test/test_jvm_compiler.rb
+++ b/test/test_jvm_compiler.rb
@@ -2099,16 +2099,20 @@ class TestJVMCompiler < Test::Unit::TestCase
     cls, = compile(<<-EOF)
       import java.util.concurrent.Callable
       def foo c:Callable
+        throws Exception
          puts c.call
       end
+      begin
       foo do
         "an object"
+      end
+      rescue
+        puts "never get here"
       end
     EOF
     assert_output("an object\n") do
       cls.main(nil)
     end
-
   end
 
   def test_each


### PR DESCRIPTION
- method body missing parent during inference caused compilation error
- javac complains that Exception needs to either be caught or thrown since main can't throw errors(currently),
  catch it
