### PR TITLE
Use java.io.File.pathSeparator instead hardcoded :

### DIFF
--- a/lib/mirah/env.rb
+++ b/lib/mirah/env.rb
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 require 'rbconfig'
+require 'java'
 
 module Mirah
   module Env
@@ -23,7 +24,7 @@ module Mirah
     # is returned
     def self.path_seperator
       ps = RbConfig::CONFIG['PATH_SEPARATOR']
-      ps = ':' if ps.nil? || ps == ''
+      ps = Java::java::io::File.pathSeparator if ps.nil? || ps == ''
       ps
     end
 


### PR DESCRIPTION
This should fix http://code.google.com/p/mirah/issues/detail?id=58 issue.

Please review that patch since I don't know anything about rbconfig and why it is used at all to obtain valid path_separator.
