### PR TITLE
Fix up env tests and a typo

### DIFF
--- a/lib/mirah/env.rb
+++ b/lib/mirah/env.rb
@@ -21,14 +21,14 @@ module Mirah
     # Returns the system PATH_SEPARATOR environment variable value. This is used when
     # separating multiple paths in one string. If none is defined then a : (colon)
     # is returned
-    def self.path_seperator
+    def self.path_separator
       File::PATH_SEPARATOR
     end
 
     # Takes an array of strings and joins them using the path_separator returning
     # a single string value
     def self.encode_paths(paths)
-      paths.join(path_seperator)
+      paths.join(path_separator)
     end
 
     # Takes a single string value "paths" and returns an array of strings containing the
@@ -37,7 +37,7 @@ module Mirah
     # is supplied it is returned as the result
     def self.decode_paths(paths, dest = nil)
       result = dest ? dest : []
-      paths.split(path_seperator).each do |path|
+      paths.split(path_separator).each do |path|
         result << path
       end
       result

--- a/test/test_env.rb
+++ b/test/test_env.rb
@@ -19,13 +19,13 @@ require 'mirah'
 class TestEnv < Test::Unit::TestCase
   include Mirah
 
-  def test_use_file_path_seperator
-    assert_equal(File::PATH_SEPARATOR, Mirah::Env.path_seperator)
+  def test_use_file_path_separator
+    assert_equal(File::PATH_SEPARATOR, Mirah::Env.path_separator)
   end
 
   def test_encode_paths_joins_paths_with_path_separator
     abc = %w[a b c]
-    assert_equal(abc.join(Mirah::Env.path_seperator), Mirah::Env.encode_paths(abc))
+    assert_equal(abc.join(Mirah::Env.path_separator), Mirah::Env.encode_paths(abc))
   end
   
   def test_encode_paths_with_single_element
@@ -38,7 +38,7 @@ class TestEnv < Test::Unit::TestCase
 
   def test_decode_paths_appends_to_second_arg
     paths_to_append = %w[a b c d]
-    encoded_paths = paths_to_append.join Mirah::Env.path_seperator
+    encoded_paths = paths_to_append.join Mirah::Env.path_separator
     path_array = ['1','2']
     
     assert_equal(['1','2','a','b','c','d'], Mirah::Env.decode_paths(encoded_paths, path_array))


### PR DESCRIPTION
I broke some tests by using `File::SEPARATOR` instead of `RbConfig`. This fixes them and changes `path_seperator` to `path_separator`
