### PR TITLE
wrap jmeta syntax errors w/ mirah ones

### DIFF
--- a/lib/mirah/transform/ast_ext.rb
+++ b/lib/mirah/transform/ast_ext.rb
@@ -47,6 +47,10 @@ module Mirah
       begin
         parser.parse(src)
       rescue => ex
+        if ex.cause.kind_of? Java::Jmeta::SyntaxError
+          ex = SyntaxError.wrap ex.cause, nil
+        end
+
         if ex.cause.respond_to? :position
           position = ex.cause.position
           Mirah.print_error(ex.cause.message, position)

--- a/test/test_ast.rb
+++ b/test/test_ast.rb
@@ -371,4 +371,10 @@ class TestAst < Test::Unit::TestCase
     assert(AST::Fixnum === new_ast)
     assert_equal(1, new_ast.literal)
   end
+  
+  def test_incorrect_syntax_raises_syntax_error
+    assert_raises SyntaxError do
+      AST.parse("puts( 'aoue'")
+    end
+  end
 end


### PR DESCRIPTION
because we didn't do this our error message printers ignored syntax errors. This wasn't an issue with using `mirah` and `mirahc` because the error would show up eventually, but with ant, the message wouldn't be printed and parsing would silently fail.

http://groups.google.com/group/mirah/browse_thread/thread/b9b009f78d75c945
