### PR TITLE
Fix for #140

### DIFF
--- a/src/org/mirah/ant/compile.mirah
+++ b/src/org/mirah/ant/compile.mirah
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import org.apache.tools.ant.BuildException
 import org.apache.tools.ant.Task
 import org.apache.tools.ant.types.Path
 import org.apache.tools.ant.types.Reference
@@ -53,15 +54,20 @@ class Compile < Task
       args.add(0, '--java') unless bytecode
       args.add(0, '-V') if verbose
 
+      # scoping hack
+      inner_exception = Exception(nil)
       begin
         MirahCommand.compile(args)
       rescue => ex
-        exception = ex
-      end
+        inner_exception = ex
+      end      
+      # scoping hack
+      exception = inner_exception
     end
     t.start
     t.join
-    raise exception if exception
+    
+    raise BuildException.new(exception) if exception
   end
 
   def setSrc(a:File):void

--- a/src/org/mirah/mirah_command.rb
+++ b/src/org/mirah/mirah_command.rb
@@ -17,6 +17,7 @@ require 'java'
 require 'mirah'
 
 java_import 'java.util.List'
+java_import 'java.lang.Exception'
 java_import 'java.lang.System'
 
 java_package "org.mirah"
@@ -44,7 +45,9 @@ class MirahCommand
 
   java_signature 'void compile(List args)'
   def self.compile(args)
-    Mirah.compile(*args)
+    if Mirah.compile(*args).nil?
+      raise "Compilation failed."
+    end
   end
 
   java_signature 'void run(List args)'


### PR DESCRIPTION
Fixes #140 by
- Raising an Exception in MirahCommand.compile if Mirah.compile fails (i.e. it returns nil)
- Allowing that exception to pass through the two layers of scope in the ant task so Ant will actually see it and fail accordingly.
