### PR TITLE
Fix command line flags in synopsis.

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -23,8 +23,8 @@ mirah <script.mirah>
 mirah -e "inline script"
 mirahc <script.mirah>
 mirahc -e "inline script" # produces DashE.class
-mirahc -java <script.mirah>
-mirahc -java -e "inline script" # produces DashE.java
+mirahc --java <script.mirah>
+mirahc --java -e "inline script" # produces DashE.java
 
 == REQUIREMENTS:
 


### PR DESCRIPTION
Example had -java instead of --java. Lets not have bad first impressions by having wrong examples.
