### PR TITLE
Ensure InlineCode.resolve return type is ResolvedType.

### DIFF
--- a/src/org/mirah/typer/special_type.mirah
+++ b/src/org/mirah/typer/special_type.mirah
@@ -30,7 +30,7 @@ class SpecialType; implements ResolvedType, TypeFuture
     true
   end
   def resolve
-    self
+    ResolvedType(self)
   end
   def name
     @name


### PR DESCRIPTION
When building Mirah with `rake jar`, I was getting the following error:

```
/home/sebastien/dev/mirah/mirah/lib/mirah/jvm/types/methods.rb:96 warning: ambiguous Java methods found, using org.mirah.typer.InlineCode(org.mirah.typer.NodeBuilder)

src/org/mirah/builtins/number_extensions.mirah:20: Error getting method type org.mirah.builtins.NumberExtensions$Extension1.quote: org.mirah.typer.InlineCode.resolve()Lorg/mirah/typer/ResolvedType;

quote {
^^^^^^^
java::lang::Math.pow(`@call.target`, `n2`)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
}
^^^^^
```

This fix ensures that InlineCode.resolve is found when compiling by coercing the return type to `ResolvedType`, which is the one expected.
