### PR TITLE
Unzip mirah-util into dist/classes so that MirahCommand gets also packaged.

### DIFF
--- a/maven/mirah-complete/pom.xml
+++ b/maven/mirah-complete/pom.xml
@@ -41,8 +41,8 @@
                   jruby -S rake jar:complete
                   rm -rf dist/classes
                   mkdir dist/classes
-                  unzip javalib/mirah-util.jar -d dist/classes &gt; /dev/null
-                  unzip dist/mirah-complete.jar -d dist/classes &gt; /dev/null
+                  unzip -o javalib/mirah-util.jar -d dist/classes &gt; /dev/null
+                  unzip -o dist/mirah-complete.jar -d dist/classes &gt; /dev/null
                 </argument>
               </arguments>
             </configuration>

--- a/maven/mirah/pom.xml
+++ b/maven/mirah/pom.xml
@@ -49,8 +49,8 @@
                   jruby -S rake jar
                   rm -rf dist/classes
                   mkdir dist/classes
-                  unzip javalib/mirah-util.jar -d dist/classes &gt; /dev/null
-                  unzip dist/mirah.jar -d dist/classes &gt; /dev/null
+                  unzip -o javalib/mirah-util.jar -d dist/classes &gt; /dev/null
+                  unzip -o dist/mirah.jar -d dist/classes &gt; /dev/null
                 </argument>
               </arguments>
             </configuration>


### PR DESCRIPTION
`MirahCommand` is now put in a separate jar, mirah-util.jar which does not
get merged into mirah.jar and mirah-complete.jar.  This fix is a temporary
workaround to package `MirahCommand` into the generated jars so that the
maven-mirah-command plugin works again.  I am working on a more “Maven-like” approach.
