### PR TITLE
Disable the -j/--java flag

### DIFF
--- a/lib/mirah/util/argument_processor.rb
+++ b/lib/mirah/util/argument_processor.rb
@@ -55,17 +55,6 @@ module Mirah
 
             self.exit_status_code = 0
             break
-          when '--java', '-j'
-            if state.command == :compile
-              require 'mirah/jvm/compiler/java_source'
-              state.compiler_class = Mirah::JVM::Compiler::JavaSource
-              args.shift
-            else
-              $stderr.puts "-j/--java flag only applies to \"compile\" mode."
-
-              self.exit_status_code = 1
-              break
-            end
           when '--jvm'
             args.shift
             state.set_jvm_version(args.shift)
@@ -132,7 +121,6 @@ module Mirah
         --explicit-packages\tRequire explicit 'package' lines in source
         -h, --help\t\tPrint this help message
         -I DIR\t\tAdd DIR to the Ruby load path before running
-        -j, --java\t\tOutput .java source (compile mode [mirahc] only)
         --jvm VERSION\t\tEmit JVM bytecode targeting specified JVM
         \t\t\t  version (1.4, 1.5, 1.6, 1.7)
         -p, --plugin PLUGIN\trequire 'mirah/plugin/PLUGIN' before running

--- a/src/org/mirah/ant/compile.mirah
+++ b/src/org/mirah/ant/compile.mirah
@@ -59,7 +59,6 @@ class Compile < Task
            '--cd', dir,
            '-c', classpath,
            src])
-      args.add(0, '--java') unless bytecode
       args.add(0, '-V') if verbose
 
       # scoping hack

--- a/test/core/util/argument_processor_test.rb
+++ b/test/core/util/argument_processor_test.rb
@@ -38,18 +38,6 @@ class ArgumentProcessorTest < Test::Unit::TestCase
 #    assert_equal path, Mirah::AST.type_factory.bootclasspath
 #  end
 
-  def test_dash_j_fails_when_not_compiling
-    state = Mirah::Util::CompilationState.new
-    processor = Mirah::Util::ArgumentProcessor.new state, ["-j"]
-
-    assert_output "-j/--java flag only applies to \"compile\" mode.\n" do
-      processor.process
-    end
-
-    assert processor.exit?
-    assert_equal 1, processor.exit_status_code
-  end
-
   def test_dash_h_prints_help_and_exits
     state = Mirah::Util::CompilationState.new
     processor = Mirah::Util::ArgumentProcessor.new state, ["-h"]


### PR DESCRIPTION
The lack of a Java source backend renders it unnecessary. As of 0.1.0, passing `--java` causes `mirahc` to crash with

```
LoadError: no such file to load -- mirah/jvm/compiler/java_source
   process at mirah-0.1.0-java/lib/mirah/util/argument_processor.rb:60
```
