### PR TITLE
Add alias method of import()

### DIFF
--- a/src/org/mirah/jvm/mirrors/jvm_scope.mirah
+++ b/src/org/mirah/jvm/mirrors/jvm_scope.mirah
@@ -162,6 +162,10 @@ class JVMScope < SimpleScope
       @imports[shortname] = fullname
     end
   end
+  
+  def add_import(fullname:String, shortname:String)
+  	self.import(fullname, shortname)
+  end
 
   def selfType:TypeFuture
     if @selfType.nil? && parent


### PR DESCRIPTION
import() cannot be used from java since import is a reserved word.  I have added add_import() as a wrapper of import() so that it can be used from java.
