### PR TITLE
Exposed loader in mirror_type_system to allow it to be overridden by cus...

### DIFF
--- a/src/org/mirah/jvm/mirrors/mirror_type_system.mirah
+++ b/src/org/mirah/jvm/mirrors/mirror_type_system.mirah
@@ -103,6 +103,7 @@ class MirrorTypeSystem implements TypeSystem
   end
 
   attr_reader context:Context
+  attr_accessor loader:SimpleAsyncMirrorLoader
 
   def self.initialize:void
     @@log = Logger.getLogger(MirrorTypeSystem.class.getName)


### PR DESCRIPTION
...tom implementation.

I have been using this modification for a while in the Mirah Netbeans module/ant task to make it possible to override the loader with my own.  It would be nice to add this to the core if it doesn't bother anybody.