### PR TITLE
This fixes a call to System.exit when mirahc is actually called from ant.

### DIFF
--- a/src/org/mirah/mirah_command.mirah
+++ b/src/org/mirah/mirah_command.mirah
@@ -24,7 +24,7 @@ class MirahCommand
   def self.compile(args:List):void
     argv = String[args.size]
     args.toArray(argv)
-    Mirahc.main(argv)
+    Mirahc.new.compile(argv)
   end
 
   def self.run(args:List):void


### PR DESCRIPTION
When being called from ant, mirahc should not call System.exit, else ant is exited, too.