### PR TITLE
fix unboxing issues for casts

### DIFF
--- a/nbproject/project.properties
+++ b/nbproject/project.properties
@@ -1,10 +1,16 @@
 bin.dir=${file.reference.duby-bin}
 examples.dir=${file.reference.duby-examples}
+file.reference.asm-5.jar=javalib/asm-5.jar
 file.reference.duby-bin=bin
 file.reference.duby-examples=examples
 file.reference.duby-lib=lib
 file.reference.duby-test=test
-javac.classpath=
+file.reference.jsr292-mock.jar=javalib/jsr292-mock.jar
+file.reference.mirah-parser.jar=javalib/mirah-parser.jar
+javac.classpath=\
+    ${file.reference.asm-5.jar};\
+    ${file.reference.jsr292-mock.jar};\
+    ${file.reference.mirah-parser.jar}
 main.file=bin/mirah
 platform.active=default
 ruby.includejava=true

--- a/src/org/mirah/jvm/compiler/bytecode.mirah
+++ b/src/org/mirah/jvm/compiler/bytecode.mirah
@@ -175,18 +175,18 @@ class Bytecode < GeneratorAdapter
     end
   end
 
-  def convertValue(currentType:JVMType, wantedType:JVMType):void
+  def convertValue(currentType:JVMType, wantedType:JVMType):void    
     unless currentType.equals(wantedType)
-      if isPrimitive(currentType) && isPrimitive(wantedType)
+      if isPrimitive(currentType) && isPrimitive(wantedType)        
         cast(currentType.getAsmType, wantedType.getAsmType)
       elsif isPrimitive(currentType)
         # TODO make sure types match
         box(currentType.getAsmType)
       elsif isPrimitive(wantedType)
         # TODO make sure types match
-        unbox(currentType.getAsmType)
-      elsif !wantedType.assignableFrom(currentType)
-        checkCast(wantedType.getAsmType)
+        unbox(wantedType.getAsmType)
+      elsif !wantedType.assignableFrom(currentType)        
+        checkCast(wantedType.getAsmType)      
       end
     end
   end

--- a/src/org/mirah/jvm/compiler/method_compiler.mirah
+++ b/src/org/mirah/jvm/compiler/method_compiler.mirah
@@ -421,11 +421,7 @@ class MethodCompiler < BaseCompiler
     compile(node.value)
     from = getInferredType(node.value)
     to = getInferredType(node)
-    if JVMTypeUtils.isPrimitive(from)
-      @builder.cast(from.getAsmType, to.getAsmType)
-    else
-      @builder.checkCast(to.getAsmType)
-    end
+    @builder.convertValue(from, to)
     @builder.pop(to) unless expression
   end
   

--- a/test/jvm/cast_test.rb
+++ b/test/jvm/cast_test.rb
@@ -159,4 +159,32 @@ class CastTest < Test::Unit::TestCase
 
     assert_equal(2, cls.foo([2, 3].to_java(:int)))
   end
+  
+  def test_implisit_unboxing_array_iteration  
+     cls, = compile(<<-EOF)
+      def foo():int
+		list = [1,2,3]
+		m = 0
+		list.each do |x:int|
+			m += x
+		end
+		return m
+      end
+    EOF
+	assert_equal(6, cls.foo())
+  end
+  
+  def test_explisit_unboxing_array_iteration  
+     cls, = compile(<<-EOF)
+      def foo():int
+		list = [1,2,3]
+		m = 0
+		list.each do |x|
+			m = int(x) + m
+		end
+		return m
+      end
+    EOF
+	assert_equal(6, cls.foo())
+  end
 end


### PR DESCRIPTION
Fix following to be working (cast_test.rb):
```ruby
 def foo():int
	list = [1,2,3]
	m = 0
	list.each do |x:int|
		m += x
	end
	return m
 end
```

```ruby
        def foo():int
		list = [1,2,3]
		m = 0
		list.each do |x|
			m = int(x) + m
		end
		return m
      end
```