### PR TITLE
Fix ant incompatibility

### DIFF
--- a/bin/mirah
+++ b/bin/mirah
@@ -24,4 +24,4 @@ rescue LoadError
   require 'mirah'
 end
 
-Mirah.run(*ARGV)
+org::mirah::tool::RunCommand.main(ARGV)

--- a/bin/mirahc
+++ b/bin/mirahc
@@ -24,4 +24,4 @@ rescue LoadError
   require 'mirah'
 end
 
-Mirah.compile(*ARGV)
+org::mirah::tool::Mirahc.main(ARGV)

--- a/src/org/mirah/mirah_command.mirah
+++ b/src/org/mirah/mirah_command.mirah
@@ -30,7 +30,7 @@ class MirahCommand
   def self.run(args:List):void
     argv = String[args.size]
     args.toArray(argv)
-    RunCommand.main(argv)
+    RunCommand.run(argv)
   end
 
   def self.main(args:String[]):void

--- a/src/org/mirah/mirah_command.mirah
+++ b/src/org/mirah/mirah_command.mirah
@@ -24,7 +24,7 @@ class MirahCommand
   def self.compile(args:List):void
     argv = String[args.size]
     args.toArray(argv)
-    Mirahc.main(argv)
+    Mirahc.new.compile(argv)
   end
 
   def self.run(args:List):void


### PR DESCRIPTION
Retry mirah/mirah#291, which cannot be reopened due to github limitations.

> It'd also be nice if you could write a couple regression tests. If you need pointers for that, I can help you out.

Yes, please. Currently, there does not seem to be much infrastructure in place to do ant-to-mirah regression tests.

it may also not seem to be worth the hassle, as the world seems to move away from ant and towards gradle. (I'm currently working on improving gradle in order to make mirah a first-class citizen in the gradle world.)