### PR TITLE
Fix bug mirah/mirah#328

### DIFF
--- a/src/org/mirah/jvm/mirrors/base_type.mirah
+++ b/src/org/mirah/jvm/mirrors/base_type.mirah
@@ -55,6 +55,7 @@ interface MirrorType < JVMType, TypeMirror
   def addMethodListener(name:String, listener:MethodListener):void; end
   def invalidateMethod(name:String):void; end
   def add(member:JVMMethod):void; end
+  def hasMember(name:String):boolean; end
   def declareField(field:JVMMethod):void; end
   def unmeta:MirrorType; end
   def isSameType(other:MirrorType):boolean; end
@@ -319,6 +320,10 @@ class BaseType implements MirrorType, DeclaredType, MethodListener
 
   def getMembers(name:String)
     List(@members[name])
+  end
+  
+  def hasMember(name:String)
+    @members[name] != nil
   end
 
   def getMethod(name:String, params:List):JVMMethod

--- a/src/org/mirah/jvm/mirrors/meta_type.mirah
+++ b/src/org/mirah/jvm/mirrors/meta_type.mirah
@@ -55,6 +55,10 @@ class MetaType < BaseType
     unmeta.addMethodListener(name, listener)
   end
 
+  def hasMember(name:String)
+    unmeta.hasMember(name)
+  end
+
   def getDeclaredField(name)
     field = unmeta.getDeclaredField(name)
     if field && Opcodes.ACC_STATIC == (Member(field).flags & Opcodes.ACC_STATIC)

--- a/src/org/mirah/jvm/mirrors/mirror_proxy.mirah
+++ b/src/org/mirah/jvm/mirrors/mirror_proxy.mirah
@@ -88,6 +88,9 @@ class MirrorProxy implements MirrorType,
   def add(member):void
     @target.add(member)
   end
+  def hasMember(name)
+    @target.hasMember(name)
+  end
   def superclass
     @target.superclass
   end

--- a/src/org/mirah/typer/simple/simple_types.mirah
+++ b/src/org/mirah/typer/simple/simple_types.mirah
@@ -192,13 +192,16 @@ class SimpleTypes; implements TypeSystem
   def getSuperClass(type)
     nil
   end
-  def defineType(scope, node, name, superclass, interfaces)
+  def createType(scope, node, name, superclass, interfaces)
     type = lookup(name)
     unless type
       type = SimpleType.new(name, false, false)
       @types[name] = type
     end
     type
+  end
+  def publishType(type_future)
+#   @types[type_future.name] = type_future # it happens already in createType
   end
   def addDefaultImports(scope)
   end

--- a/src/org/mirah/typer/typer.mirah
+++ b/src/org/mirah/typer/typer.mirah
@@ -473,9 +473,10 @@ class Typer < SimpleNodeVisitor
     name = if classdef.name
       classdef.name.identifier
     end
-    type = @types.defineType(scope, classdef, name, superclass, interfaces)
+    type = @types.createType(scope, classdef, name, superclass, interfaces)
     addScopeWithSelfType(classdef, type)
     infer(classdef.body, false) if classdef.body
+    @types.publishType(type)
     type
   end
 

--- a/src/org/mirah/typer/types.mirah
+++ b/src/org/mirah/typer/types.mirah
@@ -94,7 +94,10 @@ interface TypeSystem do
   def getSuperClass(type:TypeFuture):TypeFuture; end
 
   # Called by the Typer to inform the TypeSystem of a newly defined class.
-  def defineType(scope:Scope, node:Node, name:String, superclass:TypeFuture, interfaces:List):TypeFuture; end
+  def createType(scope:Scope, node:Node, name:String, superclass:TypeFuture, interfaces:List):TypeFuture; end
+  	
+  # Called by the Typer to inform the TypeSystem that the newly defined class has been completely populated with all its members.
+  def publishType(type_future:TypeFuture):void; end
 
   # Initializes the imports for a Script node.
   def addDefaultImports(scope:Scope):void; end

--- a/test/jvm/closure_test.rb
+++ b/test/jvm/closure_test.rb
@@ -1,0 +1,50 @@
+# Copyright (c) 2010-2013 The Mirah project authors. All Rights Reserved.
+# All contributing project authors may be found in the NOTICE file.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class ClosureTest < Test::Unit::TestCase
+
+  def test_interface_defined_after_used
+    cls, = compile(%q{
+      class FooTest1
+        def self.main(argv:String[]):void
+          FooB.new.action do
+            puts "executed foo1"
+          end
+        end
+      end
+      
+      class FooB
+        def action(foo_param:Foo_Interface):void
+          foo_param.anymethod
+        end
+      end 
+      
+      interface Foo_Interface
+        def anymethod():void; end
+      end
+      
+      class FooTest2
+        def self.main(argv:String[]):void
+          FooB.new.action do
+            puts "executed foo2"
+          end
+        end
+      end
+      FooTest2.main(String[0])
+      FooTest1.main(String[0])
+    })
+    assert_run_output("executed foo2\nexecuted foo1\n", cls)
+  end
+end


### PR DESCRIPTION
This fixes bug #328 by delaying publication of a type until the expected time when no methods will be added anymore (and thus all required methods have already been added), and constructing the closure only then.

The hasMember method is required to limit calls to the #methodChanged method to the absolute minimum, else excessive updates happen and the compiler would become much slower.

A different attempt where the type is published early (without any methods) in a "building" state and then switching the type to a "built" state (once all required methods have been added) was abandoned, due to the resolving system caching at various places by checking whether the type has changed (or has switched from error to resolved, or from null to resolved). As, when transitioning from "building" to "built", the type identity actually does not change (it has the same pointer as before), all this caching logic would have required a rewrite, which would have meant an even more invasive code modification.


The current implementation may be improved by making the construction of the closure dynamic:

1. If there is no method in the interface, then the closure is not constructed at all.
2. if there is 1 method in the interface, then the closure is constructed.
3. If there are 2 methods in the interface, then again the closure is not constructed (and existing closures are withdrawn or an error is generated), due to the intended method now being ambigous.

Whether withdrawal or error generation are actually feasible (and necessary, due to this being a corner case), is up for debate for the future. As long as withdrawal is not implemented, classes behave not as open classes (to be redefined and extended later) but as closed classes. From a Java perspective, this is fine.