### PR TITLE
Support Object.attr_Rw.

### DIFF
--- a/src/org/mirah/builtins/object_extensions.mirah
+++ b/src/org/mirah/builtins/object_extensions.mirah
@@ -187,8 +187,10 @@ class ObjectExtensions
         work.add(ProxyNode(node).get(0))
       elsif node.kind_of?(NodeList)
         list = NodeList(node)
-        list.size.times do |i|
+        i = 0
+        while i < list.size
           work.add(list.get(i))
+          i+=1
         end
       end
     end

--- a/src/org/mirah/builtins/object_extensions.mirah
+++ b/src/org/mirah/builtins/object_extensions.mirah
@@ -206,6 +206,14 @@ class ObjectExtensions
     end
   end
   
+  macro def self.attr_Rw(hash:Hash)
+    args = [hash]
+    quote do
+                attr_reader `args` # public by default
+      protected attr_writer `args`
+    end
+  end
+  
   macro def self.attr_reader(hash:Hash)
     methods = NodeList.new
     i = 0

--- a/test/jvm/macros_test.rb
+++ b/test/jvm/macros_test.rb
@@ -391,6 +391,23 @@ class MacrosTest < Test::Unit::TestCase
     assert_equal nil, cls.new.testing
   end
   
+  def test_attr_Rw
+    script, cls = compile(<<-EOF)
+      class AttrRwTest
+        attr_Rw foo:int
+        attr_Rw bar:int
+        
+        def selfreflect
+          puts self.getClass.getDeclaredMethod("foo").getModifiers
+          puts self.getClass.getDeclaredMethod("foo_set",[int.class].toArray(Class[0])).getModifiers
+        end
+      end
+
+      AttrRwTest.new.selfreflect
+    EOF
+    assert_run_output("1\n4\n", script)
+  end
+
   def test_attr_accessor
     script, cls = compile(<<-EOF)
       class AttrAccessorTest


### PR DESCRIPTION
Support attr_Rw as a compromise between attr_accessor and attr_reader. attr_Rw generates a public reader and a protected writer, which matches standard the OOP white box pattern: you are allowed to read (using the public getter) but not to write (because the setter is not public).
