### PR TITLE
mirahc support for -encoding option like javac

### DIFF
--- a/src/org/mirah/macros/builder.mirah
+++ b/src/org/mirah/macros/builder.mirah
@@ -41,7 +41,6 @@ import mirah.lang.ast.Package
 import mirah.lang.ast.RequiredArgument
 import mirah.lang.ast.Script
 import mirah.lang.ast.SimpleString
-import mirah.lang.ast.StreamCodeSource
 import mirah.lang.ast.StringCodeSource
 import mirah.lang.ast.StringConcat
 import mirah.lang.ast.TypeName
@@ -158,12 +157,6 @@ class MacroBuilder; implements org.mirah.macros.Compiler
     collector.scan(node)
     result[4] = collector.values
     Arrays.asList(result)
-  end
-
-  def deserializeScript(filename: String, code: InputStream, values: List): Script
-    script = Script(@parser.parse(StreamCodeSource.new(filename, code)))
-    ValueSetter.new(values).scan(script)
-    script
   end
 
   def deserializeAst(filename: String, startLine: int, startCol: int, code: String, values: List): Node

--- a/src/org/mirah/tool/encoded_code_source.mirah
+++ b/src/org/mirah/tool/encoded_code_source.mirah
@@ -1,0 +1,41 @@
+package org.mirah.tool
+
+import mirah.lang.ast.StringCodeSource
+import java.nio.charset.Charset
+import java.io.FileInputStream
+import java.io.InputStream
+import java.io.BufferedReader
+
+class EncodedCodeSource < StringCodeSource
+
+   def initialize(file_name: String, io:InputStream, encoding:String)
+     super(file_name, readToString(io, encoding))
+   end
+
+   def initialize(file_name:String, encoding:String)
+     initialize(file_name, FileInputStream.new(file_name), encoding)
+   end
+
+   def initialize(file_name:String)
+      initialize(file_name, FileInputStream.new(file_name), Charset.defaultCharset.name)
+   end
+
+   def initialize(file_name: String, io:InputStream)
+     initialize(file_name, io, Charset.defaultCharset.name)
+   end
+
+   def self.DEFAULT_CHARSET:String
+     Charset.defaultCharset.name
+   end
+
+  def self.readToString(stream:InputStream, encoding: String):String
+    reader = java::io::BufferedReader.new(java::io::InputStreamReader.new(stream, encoding) )
+    buffer = char[8192]
+    builder = StringBuilder.new
+    while (read = reader.read(buffer, 0, buffer.length)) > 0
+      builder.append(buffer, 0, read);
+    end
+    return builder.toString
+  end
+
+end

--- a/src/org/mirah/tool/encoded_code_source.mirah
+++ b/src/org/mirah/tool/encoded_code_source.mirah
@@ -1,3 +1,18 @@
+# Copyright (c) 2015 The Mirah project authors. All Rights Reserved.
+# All contributing project authors may be found in the NOTICE file.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 package org.mirah.tool
 
 import mirah.lang.ast.StringCodeSource
@@ -8,25 +23,26 @@ import java.io.BufferedReader
 
 class EncodedCodeSource < StringCodeSource
 
-   def initialize(file_name: String, io:InputStream, encoding:String)
-     super(file_name, readToString(io, encoding))
-   end
 
-   def initialize(file_name:String, encoding:String)
-     initialize(file_name, FileInputStream.new(file_name), encoding)
-   end
+  def initialize(file_name: String, io:InputStream, encoding:String)
+    super(file_name, readToString(io, encoding))
+  end
 
-   def initialize(file_name:String)
-      initialize(file_name, FileInputStream.new(file_name), Charset.defaultCharset.name)
-   end
+  def initialize(file_name:String, encoding:String)
+    initialize(file_name, FileInputStream.new(file_name), encoding)
+  end
 
-   def initialize(file_name: String, io:InputStream)
-     initialize(file_name, io, Charset.defaultCharset.name)
-   end
+  def initialize(file_name:String)
+    initialize(file_name, FileInputStream.new(file_name), Charset.defaultCharset.name)
+  end
 
-   def self.DEFAULT_CHARSET:String
-     Charset.defaultCharset.name
-   end
+  def initialize(file_name: String, io:InputStream)
+    initialize(file_name, io, Charset.defaultCharset.name)
+  end
+
+  def self.DEFAULT_CHARSET:String
+    'utf-8'
+  end
 
   def self.readToString(stream:InputStream, encoding: String):String
     reader = java::io::BufferedReader.new(java::io::InputStreamReader.new(stream, encoding) )

--- a/src/org/mirah/tool/mirah_arguments.mirah
+++ b/src/org/mirah/tool/mirah_arguments.mirah
@@ -31,7 +31,6 @@ import mirah.impl.MirahParser
 import mirah.lang.ast.CodeSource
 import mirah.lang.ast.Node
 import mirah.lang.ast.Script
-import mirah.lang.ast.StreamCodeSource
 import mirah.lang.ast.StringCodeSource
 import org.mirah.IsolatedResourceLoader
 import org.mirah.MirahClassLoader
@@ -74,7 +73,8 @@ class MirahArguments
                 silent: boolean,
                 max_errors: int,
                 use_type_debugger: boolean,
-                exit_status: int
+                exit_status: int,
+                encoding: String
 
   def initialize(env=System.getenv)
     @logger_color = true
@@ -86,6 +86,7 @@ class MirahArguments
     @classpath = nil
     @diagnostics = SimpleDiagnostics.new true
     @env = env
+    @encoding = EncodedCodeSource.DEFAULT_CHARSET
   end
 
   def real_macro_destination
@@ -238,6 +239,10 @@ class MirahArguments
         ['new-closures'], 'Use new closure implementation. DEPRECATED. Has no effect. The "new closure" implementation is now always used.'
     ) { System.err.puts 'Use of --new-closures has no effect and is deprecated. The "new closure" implementation is now always used.' }
 
+    parser.addFlag(
+        ['encoding'], 'ENCODING', 'File encoding. Default to OS encoding'
+    ) { |v| compiler_args.encoding = v }
+
     begin
       parser.parse(args).each do |filename: String|
         f = File.new(filename)
@@ -262,7 +267,8 @@ class MirahArguments
         end
       end
     else
-      code_sources.add(StreamCodeSource.new(f.getPath))
+      code_sources.add(EncodedCodeSource.new(f.getPath, encoding))
+      #code_sources.add(StreamCodeSource.new(f.getPath))
     end
   end
 

--- a/src/org/mirah/tool/mirah_arguments.mirah
+++ b/src/org/mirah/tool/mirah_arguments.mirah
@@ -268,7 +268,6 @@ class MirahArguments
       end
     else
       code_sources.add(EncodedCodeSource.new(f.getPath, encoding))
-      #code_sources.add(StreamCodeSource.new(f.getPath))
     end
   end
 

--- a/src/org/mirah/tool/mirah_tool.mirah
+++ b/src/org/mirah/tool/mirah_tool.mirah
@@ -30,7 +30,6 @@ import mirah.impl.MirahParser
 import mirah.lang.ast.CodeSource
 import mirah.lang.ast.Node
 import mirah.lang.ast.Script
-import mirah.lang.ast.StreamCodeSource
 import mirah.lang.ast.StringCodeSource
 import org.mirah.IsolatedResourceLoader
 import org.mirah.MirahClassLoader

--- a/src/org/mirah/typer/simple/list_wrapper.mirah
+++ b/src/org/mirah/typer/simple/list_wrapper.mirah
@@ -20,7 +20,6 @@ import org.mirah.typer.*
 import mirah.lang.ast.NodeScanner
 import mirah.lang.ast.Node
 import mirah.lang.ast.Position
-import mirah.lang.ast.StreamCodeSource
 import mirah.impl.MirahParser
 import java.io.BufferedReader
 import java.io.InputStreamReader

--- a/src/org/mirah/typer/simple/simple_scope.mirah
+++ b/src/org/mirah/typer/simple/simple_scope.mirah
@@ -20,7 +20,6 @@ import org.mirah.typer.*
 import mirah.lang.ast.NodeScanner
 import mirah.lang.ast.Node
 import mirah.lang.ast.Position
-import mirah.lang.ast.StreamCodeSource
 import mirah.impl.MirahParser
 import java.io.BufferedReader
 import java.io.InputStreamReader

--- a/src/org/mirah/typer/simple/simple_scoper.mirah
+++ b/src/org/mirah/typer/simple/simple_scoper.mirah
@@ -20,7 +20,6 @@ import org.mirah.typer.*
 import mirah.lang.ast.NodeScanner
 import mirah.lang.ast.Node
 import mirah.lang.ast.Position
-import mirah.lang.ast.StreamCodeSource
 import mirah.impl.MirahParser
 import java.io.BufferedReader
 import java.io.InputStreamReader

--- a/src/org/mirah/typer/simple/simple_type.mirah
+++ b/src/org/mirah/typer/simple/simple_type.mirah
@@ -20,7 +20,6 @@ import org.mirah.typer.*
 import mirah.lang.ast.NodeScanner
 import mirah.lang.ast.Node
 import mirah.lang.ast.Position
-import mirah.lang.ast.StreamCodeSource
 import mirah.impl.MirahParser
 import java.io.BufferedReader
 import java.io.InputStreamReader

--- a/src/org/mirah/typer/simple/simple_types.mirah
+++ b/src/org/mirah/typer/simple/simple_types.mirah
@@ -206,22 +206,3 @@ class SimpleTypes; implements TypeSystem
   def addDefaultImports(scope)
   end
 end
-
-logger = org::mirah::MirahLogFormatter.new(true).install
-logger.setLevel(java::util::logging::Level.ALL)
-parser = MirahParser.new
-code = StreamCodeSource.new("stdin", System.in)
-
-ast = Node(parser.parse(code))
-types = SimpleTypes.new('foo')
-scopes = SimpleScoper.new
-typer = Typer.new(types, scopes, nil, nil)
-
-puts "Original AST:"
-TypePrinter.new(typer).scan(ast, nil)
-puts ""
-puts "Inferring types..."
-
-typer.infer(ast, false)
-
-TypePrinter.new(typer).scan(ast, nil)

--- a/test/fixtures/cp1251_test.mirah
+++ b/test/fixtures/cp1251_test.mirah
@@ -1,7 +1,7 @@
-class РљРёСЂРёР»РёС†Р°
-  def С‚РµСЃС‚
+class Кирилица1251
+  def тест
   end
   def self.main(args:String[]):void
-    puts 'test'
+    puts 'cp1251 encoding test'
   end
 end

--- a/test/fixtures/cp1251_test.mirah
+++ b/test/fixtures/cp1251_test.mirah
@@ -1,0 +1,7 @@
+class Кирилица
+  def тест
+  end
+  def self.main(args:String[]):void
+    puts 'test'
+  end
+end

--- a/test/fixtures/utf8_test.mirah
+++ b/test/fixtures/utf8_test.mirah
@@ -2,6 +2,6 @@ class Кирилица
   def тест
   end
   def self.main(args:String[]):void
-    puts 'test'
+    puts 'default utf8 encoding test'
   end
 end

--- a/test/fixtures/utf8_test.mirah
+++ b/test/fixtures/utf8_test.mirah
@@ -1,0 +1,7 @@
+class Кирилица
+  def тест
+  end
+  def self.main(args:String[]):void
+    puts 'test'
+  end
+end

--- a/test/jvm/jvm_commands_test.rb
+++ b/test/jvm/jvm_commands_test.rb
@@ -51,8 +51,11 @@ class JVMCommandsTest < Test::Unit::TestCase
   end
 
   def test_encoding
-    assert_output "test\n" do
-      Mirah.run('-encoding','utf-8',File.dirname(__FILE__)+"/../fixtures/utf8_test.mirah")
+    assert_output "default utf8 encoding test\n" do
+      Mirah.run(File.dirname(__FILE__)+"/../fixtures/utf8_test.mirah")
+    end
+    assert_output "cp1251 encoding test\n" do
+      Mirah.run('-encoding','cp1251',File.dirname(__FILE__)+"/../fixtures/cp1251_test.mirah")
     end
   end
 end

--- a/test/jvm/jvm_commands_test.rb
+++ b/test/jvm/jvm_commands_test.rb
@@ -49,4 +49,10 @@ class JVMCommandsTest < Test::Unit::TestCase
                               )
     end
   end
+
+  def test_encoding
+    assert_output "test\n" do
+      Mirah.run('-encoding','utf-8',File.dirname(__FILE__)+"/../fixtures/utf8_test.mirah")
+    end
+  end
 end


### PR DESCRIPTION
Add an option to define source file encoding if it's different from system source encoding. Example:
mirahc -encoding utf-8 utf8_test.mirah