### PR TITLE
Fix bug https://github.com/mirah/mirah/issues/383

### DIFF
--- a/src/org/mirah/jvm/compiler/condition_compiler.mirah
+++ b/src/org/mirah/jvm/compiler/condition_compiler.mirah
@@ -61,21 +61,14 @@ class ConditionCompiler < BaseCompiler
 
   def doJump(label:Label)
     if isPrimitive(@type)
-      if "float".equals(@type.name)
-        @bytecode.push(float(0))
-        @op = "=="
-        doComparison(label)
-      elsif "double".equals(@type.name)
-        @bytecode.push(double(0))
-        @op = "=="
-        doComparison(label)
-      elsif "long".equals(@type.name)
-        @bytecode.push(long(0))
-        @op = "=="
-        doComparison(label)
-      else
+      if "boolean".equals(@type.name)
         mode = @negated ? GeneratorAdapter.EQ : GeneratorAdapter.NE
         @bytecode.ifZCmp(mode, label)
+      else # In all cases where an expression exp in "if exp" is a primitive type and not boolean, the boolean value of "exp" is always "true"
+        ("double".equals(@type.name) || "long".equals(@type.name)) ? @bytecode.pop2 : @bytecode.pop # just ignore the result of the computation 
+        if !@negated
+          @bytecode.goTo(label)
+        end
       end
     else
       if @negated

--- a/src/org/mirah/jvm/compiler/condition_compiler.mirah
+++ b/src/org/mirah/jvm/compiler/condition_compiler.mirah
@@ -65,7 +65,7 @@ class ConditionCompiler < BaseCompiler
         mode = @negated ? GeneratorAdapter.EQ : GeneratorAdapter.NE
         @bytecode.ifZCmp(mode, label)
       else # In all cases where an expression exp in "if exp" is a primitive type and not boolean, the boolean value of "exp" is always "true"
-        ("double".equals(@type.name) || "long".equals(@type.name)) ? @bytecode.pop2 : @bytecode.pop # just ignore the result of the computation 
+        pop_from_stack(@type.name) # just ignore the result of the computation
         if !@negated
           @bytecode.goTo(label)
         end
@@ -76,6 +76,16 @@ class ConditionCompiler < BaseCompiler
       else
         @bytecode.ifNonNull(label)
       end
+    end
+  end
+  
+  def pop_from_stack(typename:String)
+    # As of https://docs.oracle.com/javase/specs/jvms/se7/html/jvms-2.html#jvms-2.11.1
+    # "double", "long" are Category 2 Computational types, all other types are Category 1 Computation types.
+    if "double".equals(typename) || "long".equals(typename)
+      @bytecode.pop2
+    else
+      @bytecode.pop
     end
   end
 

--- a/src/org/mirah/jvm/mirrors/method_lookup.mirah
+++ b/src/org/mirah/jvm/mirrors/method_lookup.mirah
@@ -708,7 +708,7 @@ class LookupState
 
   def future(isField:boolean)
     if matches + macro_matches == 0
-      if inaccessible
+      if inaccessible!=0
         @context[MethodLookup].inaccessible(
             @scope, Member(@inaccessible.get(0)), @position, self)
       elsif @context[DebuggerInterface]

--- a/test/jvm/jvm_compiler_test.rb
+++ b/test/jvm/jvm_compiler_test.rb
@@ -951,6 +951,48 @@ class JVMCompilerTest < Test::Unit::TestCase
     assert_equal(false, cls.foo(nil))
   end
 
+  def test_0_is_true
+    cls, = compile("def foo(a:int);if a;true;else;false;end;end")
+    assert_equal(true, cls.foo(1))
+    assert_equal(true, cls.foo(0))
+  end
+
+  def test_0L_is_true
+    cls, = compile("def foo(a:long);if a;true;else;false;end;end")
+    assert_equal(true, cls.foo(1))
+    assert_equal(true, cls.foo(0))
+  end
+
+  def test_0_0f_is_true
+    cls, = compile("def foo(a:float);if a;true;else;false;end;end")
+    assert_equal(true, cls.foo(1.0))
+    assert_equal(true, cls.foo(0.0))
+  end
+
+  def test_0_0d_is_true
+    cls, = compile("def foo(a:double);if a;true;else;false;end;end")
+    assert_equal(true, cls.foo(1.0))
+    assert_equal(true, cls.foo(0.0))
+  end
+
+  def test_0_char_is_true
+    cls, = compile("def foo(a:char);if a;true;else;false;end;end")
+    assert_equal(true, cls.foo(1))
+    assert_equal(true, cls.foo(0))
+  end
+
+  def test_0_short_is_true
+    cls, = compile("def foo(a:short);if a;true;else;false;end;end")
+    assert_equal(true, cls.foo(1))
+    assert_equal(true, cls.foo(0))
+  end
+
+  def test_0_byte_is_true
+    cls, = compile("def foo(a:byte);if a;true;else;false;end;end")
+    assert_equal(true, cls.foo(1))
+    assert_equal(true, cls.foo(0))
+  end
+
   def test_if_expr
     cls, = compile(<<-EOF)
       def foo(a:int)

--- a/test/jvm/jvm_compiler_test.rb
+++ b/test/jvm/jvm_compiler_test.rb
@@ -944,53 +944,42 @@ class JVMCompilerTest < Test::Unit::TestCase
     assert_equal(2, cls.foo_set(2))
     assert_equal(2, cls.foo)
   end
-
-  def test_null_is_false
-    cls, = compile("def foo(a:String);if a;true;else;false;end;end")
-    assert_equal(true, cls.foo("a"))
-    assert_equal(false, cls.foo(nil))
-  end
-
-  def test_0_is_true
-    cls, = compile("def foo(a:int);if a;true;else;false;end;end")
-    assert_equal(true, cls.foo(1))
-    assert_equal(true, cls.foo(0))
-  end
-
-  def test_0L_is_true
-    cls, = compile("def foo(a:long);if a;true;else;false;end;end")
-    assert_equal(true, cls.foo(1))
-    assert_equal(true, cls.foo(0))
-  end
-
-  def test_0_0f_is_true
-    cls, = compile("def foo(a:float);if a;true;else;false;end;end")
-    assert_equal(true, cls.foo(1.0))
-    assert_equal(true, cls.foo(0.0))
-  end
-
-  def test_0_0d_is_true
-    cls, = compile("def foo(a:double);if a;true;else;false;end;end")
-    assert_equal(true, cls.foo(1.0))
-    assert_equal(true, cls.foo(0.0))
-  end
-
-  def test_0_char_is_true
-    cls, = compile("def foo(a:char);if a;true;else;false;end;end")
-    assert_equal(true, cls.foo(1))
-    assert_equal(true, cls.foo(0))
-  end
-
-  def test_0_short_is_true
-    cls, = compile("def foo(a:short);if a;true;else;false;end;end")
-    assert_equal(true, cls.foo(1))
-    assert_equal(true, cls.foo(0))
-  end
-
-  def test_0_byte_is_true
-    cls, = compile("def foo(a:byte);if a;true;else;false;end;end")
-    assert_equal(true, cls.foo(1))
-    assert_equal(true, cls.foo(0))
+  
+  def test_promotion_to_boolean
+    cases = [
+      [ "String",  "a"  => true, nil   => false ],
+      [ "boolean", true => true, false => false ],
+      [ "byte",    1    => true, 0     => true  ],
+      [ "short",   1    => true, 0     => true  ],
+      [ "int",     1    => true, 0     => true  ],
+      [ "long",    1    => true, 0     => true  ],
+      [ "char",    1    => true, 0     => true  ],
+      [ "float",   1.0  => true, 0.0   => true  ],
+      [ "double",  1.0  => true, 0.0   => true  ],
+    ].each do |type, cases|
+      cls, = compile(%Q[
+        class Foo
+          def self.foo(a:#{type})
+            if a
+              true
+            else
+              false
+            end
+          end
+          def self.foo_inverted(a:#{type})
+            unless a
+              true
+            else
+              false
+            end
+          end
+        end
+      ])
+      cases.each do |input,boolean_value|
+        assert_equal( boolean_value, cls.foo(input))
+        assert_equal(!boolean_value, cls.foo_inverted(input))
+      end
+    end
   end
 
   def test_if_expr


### PR DESCRIPTION
Only ```false``` and ```nil``` are considered ```false```. Everything else, including ```0``` is considered ```true```.