### PR TITLE
Fix read signature recursion

### DIFF
--- a/src/org/mirah/jvm/mirrors/bytecode_mirror.mirah
+++ b/src/org/mirah/jvm/mirrors/bytecode_mirror.mirah
@@ -72,7 +72,7 @@ class BytecodeMirror < AsyncMirror implements DeclaredMirrorType
   def link:void
     types = @context[MirrorTypeSystem]
     if @signature
-      invoker = TypeInvoker.new(@context, nil, [])
+      invoker = TypeInvoker.new(@context, nil, [], {})
       invoker.read(@signature)
       setSupertypes(invoker.superclass, invoker.interfaces)
       invoker.getFormalTypeParameters.each do |var|

--- a/src/org/mirah/jvm/mirrors/generics/async_type_builder.mirah
+++ b/src/org/mirah/jvm/mirrors/generics/async_type_builder.mirah
@@ -37,12 +37,13 @@ interface AsyncTypeBuilderResult
 end
 
 class AsyncTypeBuilder < SignatureVisitor
-  def initialize(context:Context, typeVariables:Map={}):void
+  def initialize(context:Context, typeVariables:Map, processed_signatures:Map):void
     super(Opcodes.ASM5)
     @context = context
     @typeVariables = typeVariables
     @types = @context[MirrorTypeSystem]
     @type_utils = @context[Types]
+    @processed_signatures = processed_signatures
   end
 
   def visitBaseType(desc)
@@ -125,12 +126,11 @@ class AsyncTypeBuilder < SignatureVisitor
       end
     end
     return if all_question_marks
-    # TODO detect cycles
-    @type = @types.parameterize(@type, args)
+    @type = @types.parameterize(@type, args, @processed_signatures)
   end
 
   def newBuilder
-    AsyncTypeBuilder.new(@context, @typeVariables)
+    AsyncTypeBuilder.new(@context, @typeVariables, @processed_signatures)
   end
 
   def future

--- a/src/org/mirah/jvm/mirrors/generics/xx_base_signature_reader.mirah
+++ b/src/org/mirah/jvm/mirrors/generics/xx_base_signature_reader.mirah
@@ -30,11 +30,16 @@ import org.mirah.util.Context
 
 abstract class BaseSignatureReader < SignatureVisitor
   def initialize(context:Context, typeVariables:Map=Collections.emptyMap):void
+    initialize(context, typeVariables, {})
+  end
+
+  def initialize(context:Context, typeVariables:Map, processed_signatures:Map):void
     super(Opcodes.ASM4)
     @context = context
     @typeVariables = Collections.checkedMap({}, String.class, TypeFuture.class)
     @typeVariables.putAll(typeVariables) if typeVariables
     @classbound = AsyncTypeBuilder(nil)
+    @processed_signatures = processed_signatures
   end
 
   attr_reader typeVariables:Map
@@ -81,11 +86,15 @@ abstract class BaseSignatureReader < SignatureVisitor
   end
 
   def newBuilder
-    AsyncTypeBuilder.new(@context, @typeVariables)
+    AsyncTypeBuilder.new(@context, @typeVariables, @processed_signatures)
   end
 
   def read(signature:String):void
     reader = SignatureReader.new(signature)
     reader.accept(self)
+  end
+
+  def processed_signatures:Map
+    @processed_signatures
   end
 end

--- a/src/org/mirah/jvm/mirrors/generics/xx_type_invoker.mirah
+++ b/src/org/mirah/jvm/mirrors/generics/xx_type_invoker.mirah
@@ -43,8 +43,8 @@ class IgnoredTypeBuilder < SignatureVisitor
 end
 
 class TypeInvoker < BaseSignatureReader
-  def initialize(context:Context, typeVars:Map, args:List)
-    super(context, typeVars)
+  def initialize(context:Context, typeVars:Map, args:List, processed_signatures:Map)
+    super(context, typeVars, processed_signatures)
     @typeParams = LinkedList.new
     @args = LinkedList.new(args)
     @interfaces = []
@@ -100,16 +100,20 @@ class TypeInvoker < BaseSignatureReader
   end
 
   def self.invoke(context:Context, type:MirrorType, args:List,
-                  outerTypeArgs:Map):MirrorType
+                  outerTypeArgs:Map, processed_signatures:Map):MirrorType
     dtype = DeclaredMirrorType(type)
     if dtype.signature.nil? || args.any? {|a| a.nil?}
       type
     else
-      invoker = TypeInvoker.new(context, outerTypeArgs, args)
-      invoker.read(dtype.signature)
+      invoker = TypeInvoker processed_signatures[dtype.signature]
+      unless invoker
+        invoker = TypeInvoker.new(context, outerTypeArgs, args, processed_signatures)
+        processed_signatures[dtype.signature] = invoker
+        invoker.read(dtype.signature)
+      end
       TypeInvocation.new(context, type,
-                         invoker.superclass, invoker.interfaces, args,
-                         invoker.getTypeVariableMap)
+                        invoker.superclass, invoker.interfaces, args,
+                        invoker.getTypeVariableMap)
     end
   end
 end

--- a/src/org/mirah/jvm/mirrors/method_lookup.mirah
+++ b/src/org/mirah/jvm/mirrors/method_lookup.mirah
@@ -712,7 +712,7 @@ class LookupState
         @context[MethodLookup].inaccessible(
             @scope, Member(@inaccessible.get(0)), @position, self)
       elsif @context[DebuggerInterface]
-        DebugError.new([["Can't find method #{@target}#{@params} II"]], @context, self)
+        DebugError.new([["Can't find method #{@target}#{@params} II #{@methods}"]], @context, self)
       else
         nil
       end

--- a/src/org/mirah/jvm/mirrors/mirror_type_system.mirah
+++ b/src/org/mirah/jvm/mirrors/mirror_type_system.mirah
@@ -115,17 +115,13 @@ class MirrorTypeSystem implements TypeSystem, ExtensionsService
     @@log = Logger.getLogger(MirrorTypeSystem.class.getName)
   end
 
-  def parameterize(type:TypeFuture, args:List)
-    parameterize type, args, {}
-  end
-
-  def parameterize(type:TypeFuture, args:List, processed_signatures:Map)
+  def parameterize(type:TypeFuture, args:List, seen_signatures:Map = {})
     context = @context
     future = DelegateFuture.new
     future.type = type
     type.onUpdate do |x, resolved|
       future.type = MirrorFuture.new(
-          TypeInvoker.invoke(context, MirrorType(resolved), args, nil, processed_signatures))
+          TypeInvoker.invoke(context, MirrorType(resolved), args, nil, seen_signatures))
     end
     future
   end

--- a/src/org/mirah/jvm/mirrors/mirror_type_system.mirah
+++ b/src/org/mirah/jvm/mirrors/mirror_type_system.mirah
@@ -22,6 +22,7 @@ import java.util.ArrayList
 import java.util.Collections
 import java.util.LinkedList
 import java.util.List
+import java.util.Map
 import org.mirah.util.Logger
 import java.util.logging.Level
 
@@ -115,14 +116,16 @@ class MirrorTypeSystem implements TypeSystem, ExtensionsService
   end
 
   def parameterize(type:TypeFuture, args:List)
-    last_resolved = nil
+    parameterize type, args, {}
+  end
+
+  def parameterize(type:TypeFuture, args:List, processed_signatures:Map)
     context = @context
-    invocation = nil
     future = DelegateFuture.new
     future.type = type
     type.onUpdate do |x, resolved|
       future.type = MirrorFuture.new(
-          TypeInvoker.invoke(context, MirrorType(resolved), args, nil))
+          TypeInvoker.invoke(context, MirrorType(resolved), args, nil, processed_signatures))
     end
     future
   end

--- a/test/jvm/generics_test.rb
+++ b/test/jvm/generics_test.rb
@@ -44,5 +44,17 @@ class GenericsTest < Test::Unit::TestCase
 
     assert_run_output("cond string\n", cls)
   end
+
+  def test_generics_recursion
+    # Class signature for java.util.stream.Stream is recursive
+    #<T:Ljava/lang/Object;>Ljava/lang/Object;Ljava/util/stream/BaseStream<TT;Ljava/util/stream/Stream<TT;>;>;
+    cls, = compile(<<-EOF)
+      [10,5,8].stream.sorted.forEach { |i| puts i}
+    EOF
+
+    assert_run_output("5\n8\n10\n", cls)
+  end
+
+
 end
 

--- a/test/jvm/generics_test.rb
+++ b/test/jvm/generics_test.rb
@@ -46,14 +46,14 @@ class GenericsTest < Test::Unit::TestCase
   end
 
   def test_generics_recursion
-    if JVMCompiler::JVM_VERSION.to_f >= 1.8
-      # Class signature for java.util.stream.Stream is recursive
-      #<T:Ljava/lang/Object;>Ljava/lang/Object;Ljava/util/stream/BaseStream<TT;Ljava/util/stream/Stream<TT;>;>;
-      cls, = compile(<<-EOF)
-        [10,5,8].stream.sorted.forEach { |i| puts i}
-      EOF
-      assert_run_output("5\n8\n10\n", cls)
-    end
+    omit_if JVMCompiler::JVM_VERSION.to_f < 1.8
+
+    # Class signature for java.util.stream.Stream is recursive
+    #<T:Ljava/lang/Object;>Ljava/lang/Object;Ljava/util/stream/BaseStream<TT;Ljava/util/stream/Stream<TT;>;>;
+    cls, = compile(<<-EOF)
+      [10,5,8].stream.sorted.forEach { |i| puts i}
+    EOF
+    assert_run_output("5\n8\n10\n", cls)
   end
 
 

--- a/test/jvm/generics_test.rb
+++ b/test/jvm/generics_test.rb
@@ -46,13 +46,14 @@ class GenericsTest < Test::Unit::TestCase
   end
 
   def test_generics_recursion
-    # Class signature for java.util.stream.Stream is recursive
-    #<T:Ljava/lang/Object;>Ljava/lang/Object;Ljava/util/stream/BaseStream<TT;Ljava/util/stream/Stream<TT;>;>;
-    cls, = compile(<<-EOF)
-      [10,5,8].stream.sorted.forEach { |i| puts i}
-    EOF
-
-    assert_run_output("5\n8\n10\n", cls)
+    if JVMCompiler::JVM_VERSION.to_f >= 1.8
+      # Class signature for java.util.stream.Stream is recursive
+      #<T:Ljava/lang/Object;>Ljava/lang/Object;Ljava/util/stream/BaseStream<TT;Ljava/util/stream/Stream<TT;>;>;
+      cls, = compile(<<-EOF)
+        [10,5,8].stream.sorted.forEach { |i| puts i}
+      EOF
+      assert_run_output("5\n8\n10\n", cls)
+    end
   end
 
 

--- a/test/mirrors/generics_test.rb
+++ b/test/mirrors/generics_test.rb
@@ -805,7 +805,7 @@ class GenericsTest < Test::Unit::TestCase
   
   def invoker_for_signature(signature)
     context   = @types.context
-    invoker   = TypeInvoker.new(context, nil, [])
+    invoker   = TypeInvoker.new(context, nil, [], {})
     invoker.read(signature)
     invoker
   end

--- a/test/mirrors/generics_test.rb
+++ b/test/mirrors/generics_test.rb
@@ -60,7 +60,7 @@ class GenericsTest < Test::Unit::TestCase
   def g(name, params)
     klass = future(name)
     params = params.map {|x| future(x)}
-    @types.parameterize(klass, params).resolve
+    @types.parameterize(klass, params, {}).resolve
   end
 
   def future(x)
@@ -797,10 +797,10 @@ class GenericsTest < Test::Unit::TestCase
   end
   
   def test_type_invoker_recursive_reference_signature
-    if JVMCompiler::JVM_VERSION.to_f >= 1.8 # Stream API is needed here
-      invoker = invoker_for_signature('<T:Ljava/lang/Object;S::Ljava/util/stream/BaseStream<TT;TS;>;>Ljava/lang/Object;Ljava/lang/AutoCloseable;')
-      assert_equal(2,invoker.getFormalTypeParameters.size)
-    end
+    omit_if JVMCompiler::JVM_VERSION.to_f < 1.8
+    # Stream API is needed here
+    invoker = invoker_for_signature('<T:Ljava/lang/Object;S::Ljava/util/stream/BaseStream<TT;TS;>;>Ljava/lang/Object;Ljava/lang/AutoCloseable;')
+    assert_equal(2,invoker.getFormalTypeParameters.size)
   end
   
   def invoker_for_signature(signature)


### PR DESCRIPTION
Provides a fix to make possible java8 stream api usage.
Currently we have StackOverflowError when parameterizing generics for Stream<T>. Example:
```
H:\code\mirah-origin-git>java -jar dist\mirahc.jar -e [].stream
 [1m* [ [34mMethodLookup [39m]  [0mError during generic method processing for java.util.Collection.stream()
java.lang.StackOverflowError
        at java.util.HashMap.<init>(HashMap.java:456)
        at java.util.HashMap.<init>(HashMap.java:467)
        at org.mirah.jvm.mirrors.BaseType.<init>(base_type.mirah:101)
        at org.mirah.jvm.mirrors.generics.TypeVariable.<init>(type_variable.mirah:28)
        at org.mirah.jvm.mirrors.generics.BaseSignatureReader.finishTypeParam(xx_base_signature_reader.mirah:61)
        at org.mirah.jvm.mirrors.generics.TypeInvoker.visitSuperclass(xx_type_invoker.mirah:71)
        at org.objectweb.asm.signature.SignatureReader.accept(Unknown Source)
        at org.mirah.jvm.mirrors.generics.BaseSignatureReader.read(xx_base_signature_reader.mirah:89)
        at org.mirah.jvm.mirrors.generics.TypeInvoker.invoke(xx_type_invoker.mirah:109)
        at org.mirah.jvm.mirrors.MirrorTypeSystem$2.updated(mirror_type_system.mirah:125)
        at org.mirah.typer.BaseTypeFuture.onUpdate(base_type_future.mirah:105)
        at org.mirah.jvm.mirrors.MirrorTypeSystem.parameterize(mirror_type_system.mirah:123)
        at org.mirah.jvm.mirrors.generics.AsyncTypeBuilder.visitEnd(async_type_builder.mirah:129)
        at org.objectweb.asm.signature.SignatureReader.a(Unknown Source)
        at org.objectweb.asm.signature.SignatureReader.a(Unknown Source)
        at org.objectweb.asm.signature.SignatureReader.accept(Unknown Source)
        at org.mirah.jvm.mirrors.generics.BaseSignatureReader.read(xx_base_signature_reader.mirah:89)
        at org.mirah.jvm.mirrors.generics.TypeInvoker.invoke(xx_type_invoker.mirah:109)
        at org.mirah.jvm.mirrors.MirrorTypeSystem$2.updated(mirror_type_system.mirah:125)
```