### PR TITLE
Implement Java array literal syntax

### DIFF
--- a/src/org/mirah/builtins/list_extensions.mirah
+++ b/src/org/mirah/builtins/list_extensions.mirah
@@ -93,4 +93,38 @@ class ListExtensions
       `result`
     end
   end
+
+  # Use as follows:
+  #   [7,3,4].as(short[])   # returns a short[] array with 3 elements
+  #   ["foo","bar"].as(String[])
+  macro def as(type)
+    import org.mirah.typer.ProxyNode
+
+    type_future        = @mirah.typer.infer(type)
+    # This code fails in case we cannot resolve the type at the time the macro is invoked
+    # (e.g. in case the type is defined after the macro invocation).
+    # We should modify the compiler to allow for a TypeFuture to be used as typeref instead.
+    arraytype_name     = type_future.resolve.name
+    arraytype_basename = arraytype_name.substring(0,arraytype_name.length-2) # remove trailing "[]", should be improved once mirah's array support is improved
+    typeref            = TypeRefImpl.new(arraytype_basename,false,false,@call.target.position)
+
+    array              = gensym
+    entries            = Array(@call.target).values
+    length             = Fixnum.new(entries.size)
+    assignments        = NodeList.new
+    
+    i = 0
+    while i < entries.size
+      entry = entries.get(i)
+      assignments.add(Call.new(quote{`array`},SimpleString.new('[]='),[Fixnum.new(i),Cast.new(entry.position,typeref,quote{`entry`})],nil))
+      i+=1
+    end
+  
+    quote do
+      `typeref`[`length`].tap do |`array`|
+        `assignments`
+      end
+    end
+  end
+
 end

--- a/test/jvm/extensions/list_extensions_test.rb
+++ b/test/jvm/extensions/list_extensions_test.rb
@@ -139,5 +139,17 @@ class ListExtensionsTest < Test::Unit::TestCase
       cls.main nil
     end
   end
+  
+  def test_array_as_type
+    cls, = compile(<<-EOF)
+      a = [5,1,3].as(short[])
+      puts a.getClass.getName
+      puts a.join(",")
+      b = ["foo","bar"].as(String[])
+      puts b.getClass.getName
+      puts b.join(",")
+    EOF
+    assert_run_output("[S\n5,1,3\n[Ljava.lang.String;\nfoo,bar\n", cls)
+  end
 
 end

--- a/test/jvm/extensions/list_extensions_test.rb
+++ b/test/jvm/extensions/list_extensions_test.rb
@@ -152,4 +152,23 @@ class ListExtensionsTest < Test::Unit::TestCase
     assert_run_output("[S\n5,1,3\n[Ljava.lang.String;\nfoo,bar\n", cls)
   end
 
+  def test_array_as_fully_qualified_type_colon2
+    cls, = compile(<<-EOF)
+      a = [5,7,4].as(java::lang::Integer[])
+      puts a.getClass.getName
+      puts a.join(",")
+    EOF
+    assert_run_output("[Ljava.lang.Integer;\n5,7,4\n", cls)
+  end
+
+  def test_array_as_fully_qualified_type_dot1
+    pend "Using a fully qualified type literal concatenated by dots as macro parameter is currently broken" do 
+      cls, = compile(<<-EOF)
+        a = [8,2,7].as(java.lang.Integer[])
+        puts a.getClass.getName
+        puts a.join(",")
+      EOF
+      assert_run_output("[Ljava.lang.Integer;\n8,2,7\n", cls)
+    end
+  end
 end


### PR DESCRIPTION
This implements https://github.com/mirah/mirah/issues/396 for one-dimensional arrays. (Multi-dimensional arrays are not properly supported, as of bug #404.)
