### PR TITLE
fix boxing for explicit return

### DIFF
--- a/src/org/mirah/jvm/compiler/method_compiler.mirah
+++ b/src/org/mirah/jvm/compiler/method_compiler.mirah
@@ -414,6 +414,8 @@ class MethodCompiler < BaseCompiler
   def visitReturn(node, expression)
     compile(node.value) unless isVoid
     handleEnsures(node, MethodDefinition.class)
+    type = getInferredType node.value
+    @builder.convertValue(type, @returnType) unless isVoid || type.nil?
     @builder.returnValue
   end
   

--- a/test/jvm/jvm_compiler_test.rb
+++ b/test/jvm/jvm_compiler_test.rb
@@ -886,7 +886,7 @@ class JVMCompilerTest < Test::Unit::TestCase
       end
 
       def unbox:boolean
-        return Boolean.new false
+        return Boolean.new(false)
       end
 
     EOF

--- a/test/jvm/jvm_compiler_test.rb
+++ b/test/jvm/jvm_compiler_test.rb
@@ -879,6 +879,21 @@ class JVMCompilerTest < Test::Unit::TestCase
     assert_run_output("A\n", cls)
   end
 
+  def test_return_boxing_and_unboxing
+    cls, = compile(<<-EOF)
+      def box:Boolean
+        return true
+      end
+
+      def unbox:boolean
+        return Boolean.new false
+      end
+
+    EOF
+    assert_equal(true, cls.box)
+    assert_equal(false, cls.unbox)
+  end
+
   def test_raise
     cls, = compile(<<-EOF)
       def foo


### PR DESCRIPTION
fix for missing boxing/unboxing conversion for explicit return. The case:
```
 def test_return_boxing_and_unboxing
    cls, = compile(<<-EOF)
      def box:Boolean
        return true
      end

      def unbox:boolean
        return Boolean.new false
      end

    EOF
    assert_equal(true, cls.box)
    assert_equal(false, cls.unbox)
  end

```
(cherry picked from commit 6c10ee2)