### PR TITLE
fix == macro for primitives

### DIFF
--- a/src/org/mirah/builtins/byte_operators.mirah
+++ b/src/org/mirah/builtins/byte_operators.mirah
@@ -68,12 +68,6 @@ class ByteOperators
     }
   end
 
-  macro def ==(n2)
-    quote {
-      `@call.target`.intValue == `n2`
-    }
-  end
-
   macro def <(n2)
     quote {
       `@call.target`.intValue < `n2`

--- a/src/org/mirah/builtins/double_operators.mirah
+++ b/src/org/mirah/builtins/double_operators.mirah
@@ -68,12 +68,6 @@ class DoubleOperators
     }
   end
 
-  macro def ==(n2)
-    quote {
-      `@call.target`.doubleValue == `n2`
-    }
-  end
-
   macro def >(n2)
     quote {
       `@call.target`.doubleValue > `n2`

--- a/src/org/mirah/builtins/float_operators.mirah
+++ b/src/org/mirah/builtins/float_operators.mirah
@@ -68,12 +68,6 @@ class FloatOperators
     }
   end
 
-  macro def ==(n2)
-    quote {
-      `@call.target`.floatValue == `n2`
-    }
-  end
-
   macro def <(n2)
     quote {
       `@call.target`.floatValue < `n2`

--- a/src/org/mirah/builtins/integer_operators.mirah
+++ b/src/org/mirah/builtins/integer_operators.mirah
@@ -68,12 +68,6 @@ class IntegerOperators
     }
   end
 
-  macro def ==(n2)
-    quote {
-      `@call.target`.intValue == `n2`
-    }
-  end
-
   macro def <(n2)
     quote {
       `@call.target`.intValue < `n2`

--- a/src/org/mirah/builtins/long_operators.mirah
+++ b/src/org/mirah/builtins/long_operators.mirah
@@ -68,12 +68,6 @@ class LongOperators
     }
   end
 
-  macro def ==(n2)
-    quote {
-      `@call.target`.longValue == `n2`
-    }
-  end
-
   macro def <(n2)
     quote {
       `@call.target`.longValue < `n2`

--- a/src/org/mirah/builtins/object_extensions.mirah
+++ b/src/org/mirah/builtins/object_extensions.mirah
@@ -42,7 +42,13 @@ class ObjectExtensions
     quote do
       `left`  = `@call.target`
       `right` = `node`
-      `left`.nil? ? `right`.nil? : `left`.equals(`right`)
+       if `left` === nil and `right` === nil
+         true
+       elsif `left` === nil
+         false
+       else
+         `left`.equals `right`
+       end
     end
   end
 

--- a/src/org/mirah/builtins/object_extensions.mirah
+++ b/src/org/mirah/builtins/object_extensions.mirah
@@ -42,10 +42,8 @@ class ObjectExtensions
     quote do
       `left`  = `@call.target`
       `right` = `node`
-       if `left` === nil and `right` === nil
-         true
-       elsif `left` === nil
-         false
+       if `left` === nil
+         `right` === nil
        else
          `left`.equals `right`
        end

--- a/src/org/mirah/builtins/short_operators.mirah
+++ b/src/org/mirah/builtins/short_operators.mirah
@@ -68,12 +68,6 @@ class ShortOperators
     }
   end
 
-  macro def ==(n2)
-    quote {
-      `@call.target`.intValue == `n2`
-    }
-  end
-
   macro def <(n2)
     quote {
       `@call.target`.intValue < `n2`

--- a/test/jvm/extensions/object_extensions_test.rb
+++ b/test/jvm/extensions/object_extensions_test.rb
@@ -108,4 +108,15 @@ class ObjectExtensionsTest < Test::Unit::TestCase
     ])
     assert_run_output("true\nfalse\nfalse\ntrue\nfalse\ntrue\nfalse\ntrue\n", cls)
   end
+
+  def test_boxing_for_numerics
+    cls, = compile(%q[
+      puts 1==Long.new(1)
+      puts Long(nil)==Long.new(1)
+      puts 1==Long.new(2)
+      puts nil == Long.new(2)
+    ])
+    assert_run_output("true\nfalse\nfalse\nfalse\n", cls)
+  end
+
 end

--- a/test/jvm/extensions/object_extensions_test.rb
+++ b/test/jvm/extensions/object_extensions_test.rb
@@ -90,4 +90,22 @@ class ObjectExtensionsTest < Test::Unit::TestCase
     ])
     assert_run_output("false\n", cls)
   end
+
+  def test_boxing_for_equals
+    cls, = compile(%q[
+      puts true==true
+      puts false==true
+      puts nil==true
+
+      obj = Boolean true
+      puts obj == true
+      puts obj == false
+
+      b = true
+      puts obj == b
+      puts obj == 1
+      puts true == obj
+    ])
+    assert_run_output("true\nfalse\nfalse\ntrue\nfalse\ntrue\nfalse\ntrue\n", cls)
+  end
 end


### PR DESCRIPTION
There was bytecode generation isssue in == macro when mixing primitives and it's wrappers
```
  def test_boxing_for_equals
    cls, = compile(%q[
      puts true==true
      puts false==true
      puts nil==true

      obj = Boolean true
      puts obj == true
      puts obj == false

      b = true
      puts obj == b
      puts obj == 1
      puts true == obj
    ])
    assert_run_output("true\nfalse\nfalse\ntrue\nfalse\ntrue\nfalse\ntrue\n", cls)
```
(cherry picked from commit 853b3d6)