### PR TITLE
Workaround for bug https://github.com/mirah/mirah/issues/420

### DIFF
--- a/src/org/mirah/builtins/object_extensions.mirah
+++ b/src/org/mirah/builtins/object_extensions.mirah
@@ -198,8 +198,8 @@ class ObjectExtensions
         end
       end
     end
-    methods_proxy.get(0).setParent(nil)
-    methods_proxy.get(0) # FIXME: if we used methods_proxy instead of methods_proxy.get(0) as return value, then the annotation is not effective
+    methods_proxy.setParent(nil)
+    methods_proxy
   end
   
   macro def self.attr_accessor(hash:Hash)

--- a/src/org/mirah/jvm/mirrors/mirror_type_system.mirah
+++ b/src/org/mirah/jvm/mirrors/mirror_type_system.mirah
@@ -56,6 +56,7 @@ import org.mirah.typer.MethodFuture
 import org.mirah.typer.MethodType
 import org.mirah.typer.NarrowingTypeFuture
 import org.mirah.typer.PickFirst
+import org.mirah.typer.ProxyNode
 import org.mirah.typer.ResolvedType
 import org.mirah.typer.Scope
 import org.mirah.typer.TypeFuture
@@ -269,8 +270,8 @@ class MirrorTypeSystem implements TypeSystem, ExtensionsService
       macro_params = LinkedList.new
       nodes = call.parameterNodes
       unless nodes.nil?
-        nodes.each do |n|
-          typename = n.getClass.getName
+        nodes.each do |n:Node|
+          typename = ProxyNode.dereference(n).getClass.getName
           macro_params.add(loadMacroType(typename))
         end
       end

--- a/src/org/mirah/macros/builder.mirah
+++ b/src/org/mirah/macros/builder.mirah
@@ -47,6 +47,7 @@ import mirah.lang.ast.SimpleString
 import mirah.lang.ast.StringCodeSource
 import mirah.lang.ast.StringConcat
 import mirah.lang.ast.TypeName
+import mirah.lang.ast.TypeRefImpl
 import mirah.lang.ast.Unquote
 import mirah.lang.ast.FunctionalCall
 import mirah.lang.ast.TypeRefImpl
@@ -385,7 +386,11 @@ class MacroBuilder; implements org.mirah.macros.Compiler
       if i == args.required_size() - 1 && arg.type.typeref.name.endsWith("Block")
         casts.add(fetchMacroBlock)
       else
-        casts.add(Cast.new(TypeName(arg.type.clone), fetchMacroArg(i)))
+        macro_arg_node = fetchMacroArg(i)
+        # Hack to allow chained macro invocations on macro invocations on MethodDefinitions.
+        # To remove this hack, https://github.com/mirah/mirah/issues/423 needs to be fixed.
+        macro_arg_node = wrap_dereference(macro_arg_node) if arg.type.typeref.name.endsWith("MethodDefinition")   
+        casts.add(Cast.new(TypeName(arg.type.clone), macro_arg_node))
       end
       i += 1
     end
@@ -433,6 +438,17 @@ class MacroBuilder; implements org.mirah.macros.Compiler
     index = Fixnum.new(i)
     clazz = Call.new(type, SimpleString.new('class'), Collections.emptyList, nil)
     FunctionalCall.new(SimpleString.new('_varargs'), [Fixnum.new(i), clazz], nil)
+  end
+
+  def wrap_dereference(node: Node): Node
+    Call.new(
+      TypeRefImpl.new('org.mirah.typer.ProxyNode', false, false, nil),
+      SimpleString.new('dereference'),
+      [
+        node,
+      ],
+      nil
+    )
   end
 
   def fetchMacroBlock: Node

--- a/src/org/mirah/typer/proxy_node.mirah
+++ b/src/org/mirah/typer/proxy_node.mirah
@@ -190,4 +190,16 @@ class ProxyNode < NodeList implements TypeName, Identifier
   def toString
     "<org.mirah.typer.ProxyNode: selected:#{@selectedNode}>"
   end
+  
+  def self.dereference(node:Node)
+    if node.kind_of?(ProxyNode)
+      ProxyNode(node).dereference
+    else
+      node
+    end
+  end
+  
+  def dereference
+    dereference(@selectedNode)
+  end
 end

--- a/test/jvm/macros_test.rb
+++ b/test/jvm/macros_test.rb
@@ -625,6 +625,37 @@ class MacrosTest < Test::Unit::TestCase
     assert_run_output("foo\n", script)
   end
   
+  def test_macro_calling_macro_calling_method_definition
+    script, cls = compile(%q{
+      class Foo
+        macro def self.foo(method:MethodDefinition)
+          method
+        end
+        
+        macro def self.bar(method:MethodDefinition)
+          method
+        end
+        
+        
+        def method0
+        end
+        
+        foo def method1
+        end
+        
+        bar def method2
+        end
+        
+        foo bar def method3
+          puts "method3"
+        end
+      end
+      
+      Foo.new.method3
+    })
+    assert_run_output("method3\n", script)
+  end
+  
   def test_gensym_clash
     script, cls = compile(%q{
       result = []


### PR DESCRIPTION
This mitigates the problem of bug #420. It does not really solve the underlying problem, as sometimes a ProxyNode needs to be dereferenced (else the correct type of the argument of the outer macro invocation is unavailable). and sometimes a ProxyNode needs to be not dereferenced (else subsequent changes to the selected node of the ProxyNode are not reflected).

This mitigation hardcodes to dereference when the expected argument type is a MethodDefinition, else to not dereference.
