### PR TITLE
Factor-out GenericsCapableSignatureReader from TypeInvoker.

### DIFF
--- a/src/org/mirah/jvm/mirrors/bytecode_mirror.mirah
+++ b/src/org/mirah/jvm/mirrors/bytecode_mirror.mirah
@@ -27,7 +27,7 @@ import org.objectweb.asm.tree.ClassNode
 import org.objectweb.asm.tree.FieldNode
 import org.objectweb.asm.tree.InnerClassNode
 import org.objectweb.asm.tree.MethodNode
-import org.mirah.jvm.mirrors.generics.TypeInvoker
+import org.mirah.jvm.mirrors.generics.GenericsCapableSignatureReader
 import org.mirah.jvm.types.JVMType
 import org.mirah.jvm.types.JVMMethod
 import org.mirah.jvm.types.JVMField
@@ -82,10 +82,10 @@ class BytecodeMirror < AsyncMirror implements DeclaredMirrorType
   def link_internal:void
     types = @context[MirrorTypeSystem]
     if @signature
-      invoker = TypeInvoker.new(@context, nil, [], {})
-      invoker.read(@signature)
-      setSupertypes(invoker.superclass, invoker.interfaces)
-      invoker.getFormalTypeParameters.each do |var|
+      signature_reader = GenericsCapableSignatureReader.new(@context)
+      signature_reader.read(@signature)
+      setSupertypes(signature_reader.superclass, signature_reader.interfaces)
+      signature_reader.getFormalTypeParameters.each do |var|
         @typeParams[var.toString] = BaseTypeFuture.new.resolved(MirrorType(var))
       end
     else

--- a/src/org/mirah/macros/builder.mirah
+++ b/src/org/mirah/macros/builder.mirah
@@ -258,6 +258,7 @@ class MacroBuilder; implements org.mirah.macros.Compiler
       import mirah.lang.ast.CallSite
       import mirah.lang.ast.Node
       import mirah.lang.ast.*
+      import java.lang.reflect.Array as ReflectArray
 
       $MacroDef[name: `macroDef.name`, arguments: `argdef`, isStatic: `isStatic`]
       class `name` implements Macro
@@ -275,24 +276,23 @@ class MacroBuilder; implements org.mirah.macros.Compiler
         end
 
         def _varargs(index:int, type:Class ):Object
-          import java.lang.reflect.Array
           parameters = @call.parameters
           block = @call.block
           vsize = parameters.size - index
 
           vargs = if block
-            Array.newInstance type, vsize + 1
+            ReflectArray.newInstance(type, vsize + 1)
           else
-            Array.newInstance type, vsize
+            ReflectArray.newInstance(type, vsize)
           end
 
           # add block as last item
-          Array.set(vargs, vsize, type.cast(block)) if block
+          ReflectArray.set(vargs, vsize, type.cast(block)) if block
 
           # downcount
           while vsize > 0
             vsize -= 1
-            Array.set(vargs, vsize, type.cast(parameters.get(index + vsize)))
+            ReflectArray.set(vargs, vsize, type.cast(parameters.get(index + vsize)))
           end
           vargs
         end

--- a/test/mirrors/generics_test.rb
+++ b/test/mirrors/generics_test.rb
@@ -28,7 +28,7 @@ class GenericsTest < Test::Unit::TestCase
   java_import 'org.mirah.jvm.mirrors.generics.Constraints'
   java_import 'org.mirah.jvm.mirrors.generics.LubFinder'
   java_import 'org.mirah.jvm.mirrors.generics.TypeInvocation'
-  java_import 'org.mirah.jvm.mirrors.generics.TypeInvoker'
+  java_import 'org.mirah.jvm.mirrors.generics.GenericsCapableSignatureReader'
   java_import 'org.mirah.jvm.mirrors.generics.TypeParameterInference'
   java_import 'org.mirah.jvm.mirrors.generics.TypeVariable'
   java_import 'org.mirah.jvm.mirrors.generics.Wildcard'
@@ -820,7 +820,7 @@ class GenericsTest < Test::Unit::TestCase
   
   def invoker_for_signature(signature)
     context   = @types.context
-    invoker   = TypeInvoker.new(context, nil, [], {})
+    invoker   = GenericsCapableSignatureReader.new(context)
     invoker.read(signature)
     invoker
   end


### PR DESCRIPTION
The TypeInvoker is actually misused as a GenericsCapableSignatureReader, doing functionality of both type incoking and reading signatures, but in both cases not performing that functionality perfectly, especially in this method:

``` mirah
  def saveTypeParam(var)
    typeVariables[var.toString] = @args.removeFirst unless @args.isEmpty
    @typeParams.add(var)
  end
```

Hence, the old TypeInvoker performing 2 distinct functions should be split into the new TypeInvoker and a GenericsCapableSignatureReader.
