### PR TITLE
Backed out: Fix NPE in generic inference.

### DIFF
--- a/src/org/mirah/jvm/mirrors/base_type.mirah
+++ b/src/org/mirah/jvm/mirrors/base_type.mirah
@@ -402,7 +402,7 @@ class AsyncMirror < BaseType
   end
 
   def interfaces:TypeFuture[]
-    @interfaces || super
+    @interfaces
   end
   
   def isFullyResolved():boolean

--- a/src/org/mirah/jvm/mirrors/generics/xx_type_invoker.mirah
+++ b/src/org/mirah/jvm/mirrors/generics/xx_type_invoker.mirah
@@ -34,7 +34,6 @@ import org.mirah.jvm.mirrors.MirrorType
 import org.mirah.jvm.model.Cycle
 import org.mirah.jvm.model.IntersectionType
 import org.mirah.typer.TypeFuture
-import org.mirah.typer.SimpleFuture
 import org.mirah.util.Context
 
 class IgnoredTypeBuilder < SignatureVisitor
@@ -56,8 +55,7 @@ class TypeInvoker < BaseSignatureReader
   end
 
   def saveTypeParam(var)
-    val = @args.isEmpty ? SimpleFuture.new(var) : @args.removeFirst
-    typeVariables[var.toString] = val
+    typeVariables[var.toString] = @args.removeFirst unless @args.isEmpty
     @typeParams.add(var)
   end
 


### PR DESCRIPTION
This fix backs out the changeset which breaks the current build.

@ribrdb The commit message of [the changeset which apparently broke the build](https://github.com/mirah/mirah/commit/ec542f68cbc3984ddd79cf1245ebb01b9f21abe8) indicates that a NullPointerException bug was attempted to being fixed. However, I was unable to find a test-case showing that NullPointerException bug in the first place. Could you find a test-case and add it to the test suite? Please also have a look at #429, it may be possible that this already fixes the test-case.