### PR TITLE
fix list assignment to use set instead of add

### DIFF
--- a/src/org/mirah/builtins/list_extensions.mirah
+++ b/src/org/mirah/builtins/list_extensions.mirah
@@ -24,7 +24,9 @@ class ListExtensions
   end
 
   macro def []=(index, value)
-    quote { `@call.target`.add `index`, `value` }
+    quote {
+     `@call.target`.set `index`, `value`
+    }
   end
 
   # Sort this List in-place, using the supplied Comparator.

--- a/test/jvm/extensions/list_extensions_test.rb
+++ b/test/jvm/extensions/list_extensions_test.rb
@@ -19,12 +19,29 @@ class ListExtensionsTest < Test::Unit::TestCase
     cls, = compile(<<-EOF)
       import java.util.ArrayList
       x = ArrayList.new
+      x.add "1"
+      x[0]= "2"
+      x[0]= "3"
+      puts x
+    EOF
+    assert_run_output("[3]\n", cls)
+  end
+
+  def test_bracket_out_of_range_exception_at_assign
+    java_import 'java.lang.IndexOutOfBoundsException'
+    cls, = compile(<<-EOF)
+      import java.util.ArrayList
+      x = ArrayList.new
       x[0]= "2"
       puts x
     EOF
-    assert_run_output("[2]\n", cls)
+    begin
+     assert_run_output("xxxx", cls)
+     fail "should rise IndexOutOfBoundsException"
+    rescue IndexOutOfBoundsException => ex
+    end
   end
-  
+
   def test_sort_with_block
     cls, = compile(<<-EOF)
       puts ([3,1,2].sort do |o0:Comparable,o1:Comparable|


### PR DESCRIPTION
currently []= macro uses List#add(index,value) which is definitely not expected.
fix to use List#set(index,value)