### PR TITLE
Fix duplicate "META-INF/services/org.mirah.macros.ExtensionsProvider" file in "mirahc.jar".

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -343,8 +343,6 @@ def bootstrap_mirah_from(old_jar, new_jar)
       zipfileset 'src' => 'javalib/asm-5.jar', 'includes' => 'org/objectweb/**/*'
       zipfileset 'src' => 'javalib/mirah-parser.jar'
       metainf 'dir' => File.dirname(__FILE__), 'includes' => 'LICENSE,COPYING,NOTICE'
-      metainf 'dir' => File.dirname(__FILE__)+'/src/org/mirah/builtins', 
-              'includes' => 'services/*'
 
       manifest do
         attribute 'name' => 'Main-Class', 'value' => 'org.mirah.MirahCommand'


### PR DESCRIPTION
The file was added both here https://github.com/mirah/mirah/blob/63a6b628c2072031e8228570cb051be59e926ef8/Rakefile#L333 and here https://github.com/mirah/mirah/blob/63a6b628c2072031e8228570cb051be59e926ef8/Rakefile#L346 .

Because of this file duplication (which is possible in .jar files), `unzip` called by the build system had been asking

```
replace dist/classes/META-INF/services/org.mirah.macros.ExtensionsProvider? [y]es, [n]o, [A]ll, [N]one, [r]ename: 
```

and thus the build did not terminate without user interaction (at least when a terminal for interactive user queries was available).
