### PR TITLE
Implement .new(length) method for Java array types.

### DIFF
--- a/src/org/mirah/builtins/array_extensions.mirah
+++ b/src/org/mirah/builtins/array_extensions.mirah
@@ -89,6 +89,17 @@ class ArrayExtensions
   end
   
   #
+  # int[].new(5)
+  #
+  macro def self.new(size)
+    array_type    = call.target
+    # basetype    = TypeName(arraytype).typeref.array_basetype
+    array_typeref = TypeName(array_type).typeref
+    basetype      = TypeRefImpl.new(array_typeref.name,false,array_typeref.isStatic,array_typeref.position)
+    EmptyArray.new(call.position, basetype, size)
+  end
+
+  #
   # int[].new(5) do |i|
   #   i+3
   # end
@@ -102,11 +113,8 @@ class ArrayExtensions
     end
     res           = gensym
     arraytype     = @call.target
-    # basetype    = TypeName(arraytype).typeref.array_basetype
-    array_typeref = TypeName(arraytype).typeref
-    basetype      = TypeRefImpl.new(array_typeref.name,false,array_typeref.isStatic,array_typeref.position)
     quote do
-      `res` = `basetype`[`size`]
+      `res` = `arraytype`.new(`size`)
       `size`.times do |`i`|
 #       `res`[`i`] = `block.body`
         `Call.new(quote{`res`},SimpleString.new('[]='),[quote{`i`},quote{`block.body`}],nil)`

--- a/test/jvm/extensions/array_extensions_test.rb
+++ b/test/jvm/extensions/array_extensions_test.rb
@@ -192,6 +192,22 @@ class ArrayExtensionsTest < Test::Unit::TestCase
     assert_run_output("4\n", cls)
   end
   
+  def test_int_array_new
+    cls, = compile(<<-EOF)
+      x = int[].new(5)
+      puts x.join(",")
+    EOF
+    assert_run_output("0,0,0,0,0\n", cls)
+  end
+
+  def test_ArrayList_array_new
+    cls, = compile(<<-EOF)
+      x = java::util::ArrayList[].new(5)
+      puts x.join(",")
+    EOF
+    assert_run_output("null,null,null,null,null\n", cls)
+  end
+
   def test_array_new
     cls, = compile(<<-EOF)
       x = int[].new(5) do |i|


### PR DESCRIPTION
Now it is permissible to write `int[].new(length)`.

This aligns creating of arrays both with Ruby’s `Array.new(length)` and with Java’s `new int[length]`.

This implements https://github.com/mirah/mirah/issues/449.